### PR TITLE
Update protobuf version in nuspec

### DIFF
--- a/NuGet/CorrugatedIron.nuspec
+++ b/NuGet/CorrugatedIron.nuspec
@@ -41,7 +41,7 @@
     <tags>Riak CorrugatedIron Corrugated Iron NoSQL Client Driver</tags>
     <dependencies>
       <dependency id="Newtonsoft.Json" version="4.5.10" />
-      <dependency id="protobuf-net" version="2.0.0.602" />
+      <dependency id="protobuf-net" version="2.0.0.640" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.configuration" />


### PR DESCRIPTION
Current builds of CorrugatedIron reference protobuf-net 2.0.0.640 (in packages folder), but the nuspec depends on the older version 2.0.0.602. This contributed to some exotic and hard-to-diagnose TypeInitializationExceptions.