### PR TITLE
Ready: Release and deployment build improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 
 # Files that must be CRLF ending
 build/build.targets text eol=crlf encoding=UTF-8
+src/NuGet/RiakClient.nuspec.template text eol=crlf encoding=UTF-8
 
 # Files that must be LF ending
 Makefile                  text eol=lf

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Regenerating .proto files
 * `.\make.cmd ProtoGen`
 
 Riak .NET Client Deployment Process
-=================================
+===================================
 
 * Merge all required feature branches into develop.
 * Verify that all tests succeed.

--- a/build/build.targets
+++ b/build/build.targets
@@ -19,46 +19,106 @@
     <Configuration>Release</Configuration>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <VersionString Condition="'$(Configuration)' == 'Release'">unknown</VersionString>
+    <VersionString Condition="'$(Configuration)' != 'Release'">v0.0.0</VersionString>
+    <GitCommitHash>unknown</GitCommitHash>
+    <MasterBranchName>master-test-147</MasterBranchName>
+    <DevelopBranchName>jira/lrb/clients-147</DevelopBranchName>
+  </PropertyGroup>
+
   <Target Name="CleanCommonAssemblyInfo">
     <Delete Files="$(CommonAssemblyInfoFile)" />
   </Target>
 
-  <Target Name="GenerateCommonAssemblyInfo">
+  <Target Name="PopulateVersionInformation">
 
-    <PropertyGroup>
-      <VMajor>0</VMajor>
-      <VMinor>0</VMinor>
-      <VPatch>0</VPatch>
-      <VBuildVer>0</VBuildVer>
-      <GitCommitHash>unknown</GitCommitHash>
-    </PropertyGroup>
-
-    <Time>
-      <Output TaskParameter="Year" PropertyName="Year" />
-    </Time>
-
-    <GitDescribe LocalPath="$(SolutionDir)" Condition="'$(Configuration)' == 'Release'">
+    <GitDescribe LocalPath="$(SolutionDir)" Condition="'$(VersionString)' == 'unknown'">
       <Output TaskParameter="CommitHash" PropertyName="GitCommitHash" />
-      <Output TaskParameter="Tag" PropertyName="GitTag" />
+      <Output TaskParameter="Tag" PropertyName="VersionString" />
     </GitDescribe>
+
+    <Message Text="Parsing VersionString: $(VersionString)" />
 
     <!--
       NB: these regexes are Mono and Windows compatible. "\." to represent literal period
           does not work on Mono 3.10
     -->
-    <RegexReplace Input="$(GitTag)" Expression="v([0-9])[.][0-9][.][0-9]" Replacement="$1" Count="1" Condition="'$(Configuration)' == 'Release'">
+    <RegexReplace Input="$(VersionString)" Expression="v([0-9])[.][0-9][.][0-9](-[a-z0-9]+)?" Replacement="$1" Count="1">
       <Output PropertyName="VMajor" TaskParameter="Output" />
     </RegexReplace>
-    <RegexReplace Input="$(GitTag)" Expression="v[0-9][.]([0-9])[.][0-9]" Replacement="$1" Count="1" Condition="'$(Configuration)' == 'Release'">
+    <RegexReplace Input="$(VersionString)" Expression="v[0-9][.]([0-9])[.][0-9](-[a-z0-9]+)?" Replacement="$1" Count="1">
       <Output PropertyName="VMinor" TaskParameter="Output" />
     </RegexReplace>
-    <RegexReplace Input="$(GitTag)" Expression="v[0-9][.][0-9][.]([0-9])" Replacement="$1" Count="1" Condition="'$(Configuration)' == 'Release'">
+    <RegexReplace Input="$(VersionString)" Expression="v[0-9][.][0-9][.]([0-9])(-[a-z0-9]+)?" Replacement="$1" Count="1">
       <Output PropertyName="VPatch" TaskParameter="Output" />
     </RegexReplace>
+    <RegexReplace Input="$(VersionString)" Expression="v[0-9][.][0-9][.][0-9]-([a-z0-9]+)?" Replacement="$1" Count="1">
+      <Output PropertyName="VPreRelease" TaskParameter="Output" />
+    </RegexReplace>
+  </Target>
 
-    <Message Text="GitTag: $(GitTag) Version: $(VMajor).$(VMinor).$(VPatch).$(VBuildVer) Commit hash: $(GitCommitHash)"/>
+  <Target Name="PublishValidateOnDevelopBranch">
+    <!-- Validate that we are on develop branch -->
+    <GitBranch LocalPath="$(SolutionDir)">
+      <Output TaskParameter="Branch" PropertyName="GitBranch" />
+    </GitBranch>
+    <Error Condition="'$(GitBranch)' != '$(DevelopBranchName)'"
+           Text="Please ensure all features have been merged into $(DevelopBranchName) and that you are on the $(DevelopBranchName) branch." />
+  </Target>
+
+  <Target Name="PublishValidateVersionString">
+    <Error Condition="'$(VersionString)' == '' Or '$(VersionString)' == 'unknown'"
+           Text="Must set VersionString property on command line!" />
+  </Target>
+
+  <Target Name="PublishValidation" DependsOnTargets="PublishValidateVersionString;PublishValidateOnDevelopBranch;PopulateVersionInformation">
+    <!-- TODO: check for NuGet token, GH token, etc -->
+    <!-- Validate parsed VersionString -->
+    <RegexMatch Input="$(VMajor)" Expression="^[1-9]$">
+      <Output PropertyName="VMajorValidated" TaskParameter="Output" />
+    </RegexMatch>
+    <Error Condition="'$(VMajorValidated)' == '' Or (!($(VMajorValidated) &gt; 0))"
+           Text="VersionString must be in vX.Y.Z-PreRelStr where X &gt; 0 and -PreRelStr is optional" />
+    <RegexMatch Input="$(VMinor)" Expression="^[0-9]$">
+      <Output PropertyName="VMinorValidated" TaskParameter="Output" />
+    </RegexMatch>
+    <Error Condition="'$(VMinorValidated)' == '' Or (!($(VMajorValidated) &gt;= 0))"
+           Text="VersionString must be in vX.Y.Z-PreRelStr where X &gt; 0 and -PreRelStr is optional" />
+    <RegexMatch Input="$(VPatch)" Expression="^[0-9]$">
+      <Output PropertyName="VPatchValidated" TaskParameter="Output" />
+    </RegexMatch>
+    <Error Condition="'$(VPatchValidated)' == '' Or (!($(VMajorValidated) &gt;= 0))"
+           Text="VersionString must be in vX.Y.Z-PreRelStr where X &gt; 0 and -PreRelStr is optional" />
+
+    <PropertyGroup Condition="'$(VPreRelease)' == ''">
+      <NuGetVersion>$(VMajor).$(VMinor).$(VPatch)</NuGetVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(VPreRelease)' != ''">
+      <NuGetVersion>$(VMajor).$(VMinor).$(VPatch)-$(VPreRelease)</NuGetVersion>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="PublishMergeMasterAndTag" DependsOnTargets="PublishValidateOnDevelopBranch">
+    <Message Text="Checking out '$(MasterBranchName)' branch" />
+    <GitClient Command="checkout" Arguments="$(MasterBranchName)" LocalPath="$(SolutionDir)" />
+    <Message Text="Cleaning '$(MasterBranchName)' branch" />
+    <GitClient Command="clean" Arguments="-fxd" LocalPath="$(SolutionDir)" />
+    <Message Text="Merging '$(DevelopBranchName)' into '$(MasterBranchName)' NOTE: this will fail if the merge can't be done via fast-forward!" />
+    <GitClient Command="merge" Arguments="--no-ff --commit --ff-only $(DevelopBranchName)" LocalPath="$(SolutionDir)" />
+    <GitClient Command="tag" Arguments="--message &quot;riak-dotnet-client $(NuGetVersion)&quot; &quot;$(NuGetVersion)&quot;" LocalPath="$(SolutionDir)" />
+  </Target>
+
+  <Target Name="GenerateCommonAssemblyInfo" DependsOnTargets="PopulateVersionInformation">
+
+    <Message Text="VersionString: $(VersionString) Version: $(VMajor).$(VMinor).$(VPatch) PreRelease: $(VPreRelease) Commit hash: $(GitCommitHash)"/>
+
+    <Time>
+      <Output TaskParameter="Year" PropertyName="Year" />
+    </Time>
 
     <Attrib Files="$(CommonAssemblyInfoFile)" ReadOnly="False" />
+
     <!-- http://stackoverflow.com/questions/64602/what-are-differences-between-assemblyversion-assemblyfileversion-and-assemblyin -->
     <AssemblyInfo CodeLanguage="CS"
                   OutputFile="$(SolutionDir)src\CommonAssemblyInfo.cs"
@@ -69,8 +129,8 @@
                   AssemblyTrademark="riak-dotnet-client"
                   AssemblyCulture=""
                   AssemblyConfiguration="$(Configuration)"
-                  AssemblyVersion="$(VMajor).$(VMinor).0.0"
-                  AssemblyFileVersion="$(VMajor).$(VMinor).$(VPatch).$(VBuildVer)"
+                  AssemblyVersion="$(VMajor).0.0"
+                  AssemblyFileVersion="$(VMajor).$(VMinor).$(VPatch)"
                   AssemblyInformationalVersion="$(GitCommitHash)" />
   </Target>
 
@@ -114,16 +174,17 @@
           Command="$(ProtoGenExe) -ns:RiakClient.Messages -i:%(ProtoFile.Identity) -o:$(ProtoMsgDir)\@(ProtoFile->'%(filename)').cs" />
   </Target>
 
-  <Target Name="NuGetRelease" DependsOnTargets="Release">
+  <Target Name="Publish" DependsOnTargets="PublishValidation;TestAll;PublishMergeMasterAndTag;Release">
     <XmlQuery XmlFileName="$(RiakClientPackagesConfig)" XPath="/packages/package[@id='Newtonsoft.Json']/@version">
       <Output TaskParameter="Values" PropertyName="NewtonsoftJsonVersion" />
     </XmlQuery>
     <XmlQuery XmlFileName="$(RiakClientPackagesConfig)" XPath="/packages/package[@id='protobuf-net']/@version">
       <Output TaskParameter="Values" PropertyName="ProtobufNetVersion" />
     </XmlQuery>
+
     <ItemGroup>
       <Tokens Include="VERSION">
-        <ReplacementValue>$(VMajor).$(VMinor).$(VPatch)</ReplacementValue>
+        <ReplacementValue>$(NuGetVersion)</ReplacementValue>
       </Tokens>
       <Tokens Include="NEWTONSOFT_JSON_VERSION">
         <ReplacementValue>$(NewtonsoftJsonVersion)</ReplacementValue>

--- a/build/build.targets
+++ b/build/build.targets
@@ -158,6 +158,8 @@
     <NUnitConsoleRunnerCommand Condition="'$(OS)' != 'Windows_NT'">$(MonoExe) $(NUnitConsoleRunnerExe) -config Debug-Mono</NUnitConsoleRunnerCommand>
 
     <RiakClientPackagesConfig>$(ProjDir)\RiakClient\packages.config</RiakClientPackagesConfig>
+
+    <PowerShellExe Condition="'$(PowerShellExe)'== ''">$(WINDIR)\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
   </PropertyGroup>
 
   <ItemGroup>
@@ -207,8 +209,13 @@
           Command="$(NuGetExe) push -NonInteractive -Verbosity normal *.nupkg" />
   </Target>
 
+  <Target Name="PublishGitHubRelease" DependsOnTargets="PublishValidation">
+    <Exec WorkingDirectory="$(SolutionDir)"
+          Command="$(PowerShellExe) -NonInteractive -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)build\create-github-release.ps1 $(VersionString)" />
+  </Target>
+
   <Target Name="Publish"
-          DependsOnTargets="PublishValidation;TestAll;PublishMergeMasterAndTag;Release;PublishNuGetPackage" />
+          DependsOnTargets="PublishValidation;TestAll;PublishMergeMasterAndTag;Release;PublishNuGetPackage;PublishGitHubRelease" />
 
   <Target Name="GitSubmodule" Condition="!Exists('$(ProtoMsgCsvFile)')">
     <GitClient Command="submodule" Arguments="update --init" LocalPath="$(SolutionDir)" />

--- a/build/build.targets
+++ b/build/build.targets
@@ -38,6 +38,10 @@
       <Output TaskParameter="Tag" PropertyName="VersionString" />
     </GitDescribe>
 
+    <GitDescribe LocalPath="$(SolutionDir)" Condition="'$(Configuration)' == 'Release' And '$(VersionString)' != 'unknown'">
+      <Output TaskParameter="CommitHash" PropertyName="GitCommitHash" />
+    </GitDescribe>
+
     <Message Text="Parsing VersionString: $(VersionString)" />
 
     <!--
@@ -97,6 +101,9 @@
     <PropertyGroup Condition="'$(VPreRelease)' != ''">
       <NuGetVersion>$(VMajor).$(VMinor).$(VPatch)-$(VPreRelease)</NuGetVersion>
     </PropertyGroup>
+    <PropertyGroup>
+      <GitTagVersion>v$(NuGetVersion)</GitTagVersion>
+    </PropertyGroup>
   </Target>
 
   <Target Name="PublishMergeMasterAndTag" DependsOnTargets="PublishValidateOnDevelopBranch">
@@ -106,7 +113,7 @@
     <GitClient Command="clean" Arguments="-fxd" LocalPath="$(SolutionDir)" />
     <Message Text="Merging '$(DevelopBranchName)' into '$(MasterBranchName)' NOTE: this will fail if the merge can't be done via fast-forward!" />
     <GitClient Command="merge" Arguments="--no-ff --commit --ff-only $(DevelopBranchName)" LocalPath="$(SolutionDir)" />
-    <GitClient Command="tag" Arguments="--message &quot;riak-dotnet-client $(NuGetVersion)&quot; &quot;$(NuGetVersion)&quot;" LocalPath="$(SolutionDir)" />
+    <GitClient Command="tag" Arguments="--message &quot;riak-dotnet-client $(NuGetVersion)&quot; &quot;$(GitTagVersion)&quot;" LocalPath="$(SolutionDir)" />
   </Target>
 
   <Target Name="GenerateCommonAssemblyInfo" DependsOnTargets="PopulateVersionInformation">

--- a/build/build.targets
+++ b/build/build.targets
@@ -23,8 +23,8 @@
     <VersionString Condition="'$(Configuration)' == 'Release'">unknown</VersionString>
     <VersionString Condition="'$(Configuration)' != 'Release'">v0.0.0</VersionString>
     <GitCommitHash>unknown</GitCommitHash>
-    <MasterBranchName>master-test-147</MasterBranchName>
-    <DevelopBranchName>jira/lrb/clients-147</DevelopBranchName>
+    <MasterBranchName>master</MasterBranchName>
+    <DevelopBranchName>develop</DevelopBranchName>
   </PropertyGroup>
 
   <Target Name="CleanCommonAssemblyInfo">
@@ -77,7 +77,6 @@
   </Target>
 
   <Target Name="PublishValidation" DependsOnTargets="PublishValidateVersionString;PublishValidateOnDevelopBranch;PopulateVersionInformation">
-    <!-- TODO: check for NuGet token, GH token, etc -->
     <!-- Validate parsed VersionString -->
     <RegexMatch Input="$(VMajor)" Expression="^[1-9]$">
       <Output PropertyName="VMajorValidated" TaskParameter="Output" />
@@ -150,8 +149,9 @@
     <ProtoMsgDir>$(SolutionDir)src\RiakClient\Messages</ProtoMsgDir>
     <ProtoMsgCsvFile>$(ProtoDir)\riak_pb_messages.csv</ProtoMsgCsvFile>
     <NuGetExe>$(SolutionDir).nuget\NuGet.exe</NuGetExe>
-    <NuGetSpecTemplate>$(ProjDir)\NuGet\RiakClient.nuspec.template</NuGetSpecTemplate>
-    <NuGetSpecFile>$(ProjDir)\NuGet\RiakClient.nuspec</NuGetSpecFile>
+    <NuGetDir>$(ProjDir)\NuGet</NuGetDir>
+    <NuGetSpecTemplate>$(NuGetDir)\RiakClient.nuspec.template</NuGetSpecTemplate>
+    <NuGetSpecFile>$(NuGetDir)\RiakClient.nuspec</NuGetSpecFile>
 
     <NUnitConsoleRunnerExe>$(SolutionDir)packages\NUnit.Runners.2.6.3\tools\nunit-console.exe -nologo -nodots</NUnitConsoleRunnerExe>
     <NUnitConsoleRunnerCommand Condition="'$(OS)' == 'Windows_NT'">$(NUnitConsoleRunnerExe) -config Debug</NUnitConsoleRunnerCommand>
@@ -181,7 +181,7 @@
           Command="$(ProtoGenExe) -ns:RiakClient.Messages -i:%(ProtoFile.Identity) -o:$(ProtoMsgDir)\@(ProtoFile->'%(filename)').cs" />
   </Target>
 
-  <Target Name="PublishBuildNuGetPackage" DependsOnTargets="PublishValidation">
+  <Target Name="PublishNuGetPackage" DependsOnTargets="PublishValidation">
     <XmlQuery XmlFileName="$(RiakClientPackagesConfig)" XPath="/packages/package[@id='Newtonsoft.Json']/@version">
       <Output TaskParameter="Values" PropertyName="NewtonsoftJsonVersion" />
     </XmlQuery>
@@ -201,12 +201,14 @@
       </Tokens>
     </ItemGroup>
     <TemplateFile Template="$(NuGetSpecTemplate)" OutputFileName="$(NuGetSpecFile)" Tokens="@(Tokens)" />
-    <Exec WorkingDirectory="$(ProjDir)\NuGet"
+    <Exec WorkingDirectory="$(NuGetDir)"
           Command="$(NuGetExe) pack -Symbols -Verbosity normal $(NuGetSpecFile)" />
+    <Exec WorkingDirectory="$(NuGetDir)"
+          Command="$(NuGetExe) push -NonInteractive -Verbosity normal *.nupkg" />
   </Target>
 
   <Target Name="Publish"
-          DependsOnTargets="PublishValidation;UnitTest;PublishMergeMasterAndTag;Release;PublishBuildNuGetPackage" /> <!-- TODO change to TestAll -->
+          DependsOnTargets="PublishValidation;TestAll;PublishMergeMasterAndTag;Release;PublishNuGetPackage" />
 
   <Target Name="GitSubmodule" Condition="!Exists('$(ProtoMsgCsvFile)')">
     <GitClient Command="submodule" Arguments="update --init" LocalPath="$(SolutionDir)" />

--- a/build/build.targets
+++ b/build/build.targets
@@ -174,7 +174,7 @@
           Command="$(ProtoGenExe) -ns:RiakClient.Messages -i:%(ProtoFile.Identity) -o:$(ProtoMsgDir)\@(ProtoFile->'%(filename)').cs" />
   </Target>
 
-  <Target Name="Publish" DependsOnTargets="PublishValidation;TestAll;PublishMergeMasterAndTag;Release">
+  <Target Name="PublishBuildNuGetPackage" DependsOnTargets="PublishValidation">
     <XmlQuery XmlFileName="$(RiakClientPackagesConfig)" XPath="/packages/package[@id='Newtonsoft.Json']/@version">
       <Output TaskParameter="Values" PropertyName="NewtonsoftJsonVersion" />
     </XmlQuery>
@@ -197,6 +197,9 @@
     <Exec WorkingDirectory="$(ProjDir)\NuGet"
           Command="$(NuGetExe) pack -Symbols -Verbosity normal $(NuGetSpecFile)" />
   </Target>
+
+  <Target Name="Publish"
+          DependsOnTargets="PublishValidation;UnitTest;PublishMergeMasterAndTag;Release;PublishBuildNuGetPackage" /> <!-- TODO change to TestAll -->
 
   <Target Name="GitSubmodule" Condition="!Exists('$(ProtoMsgCsvFile)')">
     <GitClient Command="submodule" Arguments="update --init" LocalPath="$(SolutionDir)" />

--- a/build/create-github-release.ps1
+++ b/build/create-github-release.ps1
@@ -1,0 +1,56 @@
+Set-StrictMode -Version Latest
+
+function Get-ScriptPath {
+	$scriptDir = Get-Variable PSScriptRoot -ErrorAction SilentlyContinue | ForEach-Object { $_.Value }
+	if (!$scriptDir) {
+		if ($MyInvocation.MyCommand.Path) {
+			$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+		}
+	}
+	if (!$scriptDir) {
+		if ($ExecutionContext.SessionState.Module.Path) {
+			$scriptDir = Split-Path (Split-Path $ExecutionContext.SessionState.Module.Path)
+		}
+	}
+	if (!$scriptDir) {
+		$scriptDir = $PWD
+	}
+	return $scriptDir
+}
+
+$release_zip_path = Resolve-Path ($(Get-ScriptPath) + '\..\src\RiakClient\bin\Release\RiakClient.zip')
+Write-Host -ForegroundColor Yellow $release_zip_path
+exit 0
+
+$github_api_key_file = '~/.ghapi'
+
+if (Test-Path $github_api_key_file) {
+    $github_api_key = Get-Content ~/.ghapi
+    Write-Host -ForegroundColor Green "GitHub API Key '$github_api_key'"
+}
+else {
+    throw "GitHub API Key must be in file '$github_api_key_file'"
+}
+
+$headers = @{ Authorization = "token $github_api_key" }
+
+$release_info = New-Object PSObject -Property @{
+        tag_name = "v2.0.0-beta1"
+        target_commitish = "master"
+        name = "v2.0.0-beta1"
+        body ="riak-dotnet-client 2.0.0-beta1"
+        draft = $false
+        prerelease = $true
+    }
+
+$release_json = ConvertTo-Json -InputObject $release_info -Compress
+
+$response = Invoke-WebRequest -Headers $headers -ContentType 'application/json' -Method Post -Body $release_json -Uri 'https://api.github.com/repos/basho-labs/riak-dotnet-client/releases'
+
+if (!($response.StatusCode == 201)) {
+    throw "Creating release failed: $response.StatusCode"
+}
+
+$response_json = ConvertFrom-Json -InputObject $response.Content
+$assets_url_with_name = $response_json.assets_url + '?name=' + $release_zip_name
+$response = Get-Content $release_zip_path | Invoke-WebRequest -Headers $headers -ContentType 'application/zip' -Method Post -Uri $assets_url_with_name

--- a/build/create-github-release.ps1
+++ b/build/create-github-release.ps1
@@ -21,22 +21,26 @@ Param(
 
 Set-StrictMode -Version Latest
 
+# Note:
+# Set to Continue to see DEBUG messages
+# $DebugPreference = 'SilentlyContinue'
+
 function Get-ScriptPath {
-	$scriptDir = Get-Variable PSScriptRoot -ErrorAction SilentlyContinue | ForEach-Object { $_.Value }
-	if (!$scriptDir) {
-		if ($MyInvocation.MyCommand.Path) {
-			$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
-		}
-	}
-	if (!$scriptDir) {
-		if ($ExecutionContext.SessionState.Module.Path) {
-			$scriptDir = Split-Path (Split-Path $ExecutionContext.SessionState.Module.Path)
-		}
-	}
-	if (!$scriptDir) {
-		$scriptDir = $PWD
-	}
-	return $scriptDir
+  $scriptDir = Get-Variable PSScriptRoot -ErrorAction SilentlyContinue | ForEach-Object { $_.Value }
+  if (!$scriptDir) {
+    if ($MyInvocation.MyCommand.Path) {
+      $scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+    }
+  }
+  if (!$scriptDir) {
+    if ($ExecutionContext.SessionState.Module.Path) {
+      $scriptDir = Split-Path (Split-Path $ExecutionContext.SessionState.Module.Path)
+    }
+  }
+  if (!$scriptDir) {
+    $scriptDir = $PWD
+  }
+  return $scriptDir
 }
 
 $release_zip_name = 'RiakClient.zip'
@@ -61,13 +65,13 @@ $release_info = New-Object PSObject -Property @{
 $release_json = ConvertTo-Json -InputObject $release_info -Compress
 
 $response = Invoke-WebRequest -Headers $headers -ContentType 'application/json' -Method Post -Body $release_json -Uri 'https://api.github.com/repos/basho-labs/riak-dotnet-client/releases'
-
 if (!($response.StatusCode == 201)) {
     throw "Creating release failed: $response.StatusCode"
 }
 
 $response_json = ConvertFrom-Json -InputObject $response.Content
 $assets_url_with_name = $response_json.assets_url + '?name=' + $release_zip_name
+
 $response = Get-Content $release_zip_path | Invoke-WebRequest -Headers $headers -ContentType 'application/zip' -Method Post -Uri $assets_url_with_name
 if (!($response.StatusCode == 201)) {
     throw "Creating release failed: $response.StatusCode"

--- a/make.cmd
+++ b/make.cmd
@@ -33,11 +33,14 @@ if (%TARGET%)==() set TARGET=Debug
 set VERBOSITY=%2
 if (%VERBOSITY%)==() set VERBOSITY=Normal
 
+set VERSIONSTRING=%3
+if not (%VERSIONSTRING%)==() set VERSIONPROPERTY=/property:VersionString=%VERSIONSTRING%
+
 %NUGETEXE% restore -PackagesDirectory %CURDIR%\packages .nuget\packages.config
 if errorlevel 1 goto ERR_FAILED
 
 rem NB: this will always do build for Release *and* Debug configuration
-%MSBUILDEXE% /verbosity:%VERBOSITY% /nologo /m /property:SolutionDir=%CURDIR% /target:%TARGET% %CURDIR%\build\build.targets
+%MSBUILDEXE% /verbosity:%VERBOSITY% /nologo /m /property:SolutionDir=%CURDIR% %VERSIONPROPERTY% /target:%TARGET% %CURDIR%\build\build.targets
 if errorlevel 1 goto ERR_FAILED
 
 echo.

--- a/src/NuGet/RiakClient.nuspec.template
+++ b/src/NuGet/RiakClient.nuspec.template
@@ -58,6 +58,7 @@
     <file src="..\RiakClient\bin\Release\RiakClient.pdb" target="lib\net40" />
     <file src="..\RiakClient\bin\Release\RiakClient.xml" target="lib\net40" />
     <file src="..\RiakClient\**\*.cs" target="src" />
+    <file src="..\CommonAssemblyInfo.cs" target="src" />
   </files>
 </package>
 

--- a/src/NuGet/RiakClient.nuspec.template
+++ b/src/NuGet/RiakClient.nuspec.template
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <!--
 // Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright (c) 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file
@@ -38,7 +39,7 @@
     <iconUrl>http://corrugatediron.org/nugeticon.png</iconUrl>
     <licenseUrl>http://corrugatediron.org/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <tags>Riak .NET RiakClient CorrugatedIron Corrugated Iron NoSQL Client Driver Distributed</tags>
+    <tags>Riak .NET Client CorrugatedIron Corrugated Iron NoSQL Client Driver Distributed</tags>
     <dependencies>
       <dependency id="Newtonsoft.Json" version="${NEWTONSOFT_JSON_VERSION}" />
       <dependency id="protobuf-net" version="${PROTOBUF_NET_VERSION}" />

--- a/src/NuGet/RiakClient.nuspec.template
+++ b/src/NuGet/RiakClient.nuspec.template
@@ -20,6 +20,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>RiakClient</id>
+    <title>Riak .NET Client</title>
     <version>${VERSION}</version>
     <authors>OJ Reeves, Jeremiah Peschka, Alex Moore, Luke Bakken</authors>
     <owners>Basho Technologies, Inc.</owners>

--- a/src/NuGet/RiakClient.nuspec.template
+++ b/src/NuGet/RiakClient.nuspec.template
@@ -22,11 +22,12 @@
     <id>RiakClient</id>
     <version>${VERSION}</version>
     <authors>OJ Reeves, Jeremiah Peschka, Alex Moore, Luke Bakken</authors>
-    <owners>OJ Reeves, Jeremiah Peschka, Basho Technologies Inc.</owners>
+    <owners>Basho Technologies, Inc.</owners>
+    <copyright>© 2011-2014 OJ Reeves &amp; Jeremiah Peschka / © 2015 Basho Technologies, Inc.</copyright>
     <description>
       Riak .NET Client - the .NET client for Riak.
 
-      Riak is a distributed, fault tolerant, highly-available Key/Value store written by Basho Technologies. Riak is Open Source and written in Erlang. Riak .NET Client exposes the features of Riak through a developer-friendly API.
+      Riak is a distributed, fault tolerant, highly-available Key/Value store written by Basho Technologies. Riak .NET Client exposes the features of Riak through a developer-friendly API.
 
       After installing this package, make sure that you modify either the app.config (for client apps) or web.config (for web apps) so that the details of the target Riak cluster are set correctly.
 
@@ -37,9 +38,9 @@
     </summary>
     <projectUrl>http://corrugatediron.org/</projectUrl>
     <iconUrl>http://corrugatediron.org/nugeticon.png</iconUrl>
-    <licenseUrl>http://corrugatediron.org/LICENSE.txt</licenseUrl>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <tags>Riak .NET Client CorrugatedIron Corrugated Iron NoSQL Client Driver Distributed</tags>
+    <tags>Riak .NET Client riak-dotnet-client CorrugatedIron Corrugated Iron NoSQL Client Driver Distributed</tags>
     <dependencies>
       <dependency id="Newtonsoft.Json" version="${NEWTONSOFT_JSON_VERSION}" />
       <dependency id="protobuf-net" version="${PROTOBUF_NET_VERSION}" />
@@ -58,3 +59,4 @@
     <file src="..\RiakClient\**\*.cs" target="src" />
   </files>
 </package>
+

--- a/src/RiakClient/RiakClient.csproj
+++ b/src/RiakClient/RiakClient.csproj
@@ -293,4 +293,12 @@
   <Target Name="BeforeClean">
     <CallTarget Targets="CleanCommonAssemblyInfo" />
   </Target>
+  <Target Name="AfterBuild" Condition="'$(Configuration)' == 'Release'">
+    <ItemGroup>
+      <ZipFiles Include="$(OutputPath)*.dll" />
+      <ZipFiles Include="$(OutputPath)*.xml" />
+      <ZipFiles Include="$(OutputPath)*.pdb" />
+    </ItemGroup>
+    <Zip Files="@(ZipFiles)" WorkingDirectory="$(OutputPath)" ZipFileName="$(OutputPath)$(AssemblyName).zip" ZipLevel="9" />
+  </Target>
 </Project>


### PR DESCRIPTION
CLIENTS-147

Deploying an "official" Riak .NET Client release should involve a single command and do the following:

* Support beta releases (http://docs.nuget.org/docs/reference/versioning)
* Run all tests and code analysis tools
* If the above is successful, tag the current sha with the correct version string
* Build nuget package and upload
* Create release in GitHub and upload zip of release and any supporting files